### PR TITLE
Update plus.html

### DIFF
--- a/plus.html
+++ b/plus.html
@@ -247,7 +247,7 @@ For changes in other releases, click below:<br>
 <li>Passed boothowto from the sparc64 bootloader to the kernel using .openbsd.bootdata.
 <li>Added <a href="https://man.openbsd.org/wsmoused">wsmoused(8)</a> support to <a href="https://man.openbsd.org/efifb">efifb(4)</a>.
 <li>Added support for the ThingM blink(1) USB notification light.
-<li>Stopped <a href="https://man.openbsd.org/syslogd">syslogd(8)</a> from closing UDP sockets for sending messages when DNS lookup of a UDP loghost fails, alloiwing them to be used to send if DNS is working during the next SIGHUP.
+<li>Stopped <a href="https://man.openbsd.org/syslogd">syslogd(8)</a> from closing UDP sockets for sending messages when DNS lookup of a UDP loghost fails, allowing them to be used to send if DNS is working during the next SIGHUP.
 <li>Made non-root filesystems FFS2 for landisk, sgi and luna88k.
 <!-- 2020/05/24 -->
 <li>Made <a href="https://man.openbsd.org/ldomctl">ldomctl(8)</a> "init-system -n" check vcpu and memory constraints.


### PR DESCRIPTION
fix typo

Stopped syslogd(8) from closing UDP sockets for sending messages when DNS lookup of a UDP loghost fails, alloiwing them to be used to send if DNS is working during the next SIGHUP. 

Stopped syslogd(8) from closing UDP sockets for sending messages when DNS lookup of a UDP loghost fails, allowing them to be used to send if DNS is working during the next SIGHUP. 